### PR TITLE
Fix incorrect Portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -458,7 +458,7 @@ msgstr "Nomes alternativos do portador"
 
 #: ../ui/gcr-certificate-renderer.c:266
 msgid "Extension"
-msgstr "Ramal"
+msgstr "Extensão"
 
 #: ../ui/gcr-certificate-renderer.c:270
 msgid "Identifier"


### PR DESCRIPTION
The Portuguese translation file contains an error: the translation for "Extension" is "Extensão", not "Ramal".

"Ramal" is used exclusively for phone extensions (the kind you have to dial extra digits to get to the right device). This is extremely confusing because the certificate details may contain information related to phone numbers, but this is not one of them.

I'm not sure this is the right channel to propose a change, so any help on this direction will be appreciated.
