### PR TITLE
Respect CPP overriding

### DIFF
--- a/gck/Makefile.am
+++ b/gck/Makefile.am
@@ -168,7 +168,7 @@ gck-$(GCK_MAJOR).pc: gck/gck.pc
 	$(AM_V_GEN) cp gck/gck.pc gck-$(GCK_MAJOR).pc
 
 gck-expected.abi: gck/gck.symbols
-	$(AM_V_GEN) cpp -P $< | sort > $@
+	$(AM_V_GEN) $(CPP) -P $< | sort > $@
 
 gck-actual.abi: $(builddir)/.libs/libgck-@GCK_MAJOR@.so
 	$(AM_V_GEN)  $(NM) -D -g --defined-only $< | \

--- a/gcr/Makefile.am
+++ b/gcr/Makefile.am
@@ -243,7 +243,7 @@ endif # HAVE_INTROSPECTON
 # ----------------------------------------------------------------
 
 gcr-base-expected.abi: gcr/gcr-base.symbols
-	$(AM_V_GEN) cpp -P $< | sort > $@
+	$(AM_V_GEN) $(CPP) -P $< | sort > $@
 
 gcr-base-actual.abi: $(builddir)/.libs/libgcr-base-@GCR_MAJOR@.so
 	$(AM_V_GEN)  $(NM) -D -g --defined-only $< | \

--- a/ui/Makefile.am
+++ b/ui/Makefile.am
@@ -185,7 +185,7 @@ pkgconfig_DATA += \
 	gcr-ui-$(GCR_MAJOR).pc
 
 gcr-ui-expected.abi: ui/gcr-ui.symbols
-	$(AM_V_GEN) cpp -P $< | sort > $@
+	$(AM_V_GEN) $(CPP) -P $< | sort > $@
 
 desktopdir = $(datadir)/applications
 desktop_in_in_files = ui/gcr-viewer.desktop.in.in ui/gcr-prompter.desktop.in.in


### PR DESCRIPTION
Some distribution (ex. Exherbo) use target-prefixed binutils/compilers/etc. `cpp` is one of them (`x86_64-pc-linux-gnu-cpp`).

Let's use `$(CPP)` variable already provided by autotools.
