### PR TITLE
gcr: add missing dependencies for vapi

### DIFF
--- a/gcr/Makefile.am
+++ b/gcr/Makefile.am
@@ -221,7 +221,7 @@ gir_DATA += Gcr-@GCR_MAJOR@.gir
 
 if ENABLE_VAPIGEN
 
-gcr-@GCR_MAJOR@.vapi: Gcr-@GCR_MAJOR@.gir gcr/Gcr-@GCR_MAJOR@.metadata gcr-@GCR_MAJOR@.deps
+gcr-@GCR_MAJOR@.vapi: Gcr-@GCR_MAJOR@.gir gcr/Gcr-@GCR_MAJOR@.metadata gcr-@GCR_MAJOR@.deps gck-@GCK_MAJOR@.vapi
 
 VAPIGEN_VAPIS += gcr-@GCR_MAJOR@.vapi
 

--- a/ui/Makefile.am
+++ b/ui/Makefile.am
@@ -160,7 +160,7 @@ gir_DATA += GcrUi-@GCR_MAJOR@.gir
 
 if ENABLE_VAPIGEN
 
-gcr-ui-@GCR_MAJOR@.vapi: GcrUi-@GCR_MAJOR@.gir ui/GcrUi-@GCR_MAJOR@.metadata gcr-ui-@GCR_MAJOR@.deps
+gcr-ui-@GCR_MAJOR@.vapi: GcrUi-@GCR_MAJOR@.gir ui/GcrUi-@GCR_MAJOR@.metadata gcr-ui-@GCR_MAJOR@.deps gck-@GCK_MAJOR@.vapi gcr-@GCR_MAJOR@.vapi
 
 VAPIGEN_VAPIS += gcr-ui-@GCR_MAJOR@.vapi
 


### PR DESCRIPTION
According to the vapi_DEPS definition:
gcr-3.vapi depends on gck-1.vapi,
gcr-ui-3.vapi depends on gck-1.vapi and gcr-3.vapi

But these dependencies are missing for the make targets,
so it will fail when build in parallel:
error: Package `gck-1' not found in specified Vala API directories or GObject-Introspection GIR directories
error: Package `gcr-3' not found in specified Vala API directories or GObject-Introspection GIR directories

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>