### PR TITLE
Properly DER encode CKA_EC_POINT

### DIFF
--- a/egg/pk.asn
+++ b/egg/pk.asn
@@ -118,6 +118,9 @@ ECParameters ::= CHOICE {
 
 -- rfc5915 (EC private key structure)
 
+-- bogus attribute used to encode Q into PKCS#11 CKA_EC_POINT
+ECKeyQ ::= OCTET STRING
+
 ECPrivateKey ::= SEQUENCE {
   version        INTEGER { ecPrivkeyVer1(1) },
   privateKey     OCTET STRING,

--- a/egg/pk.asn.h
+++ b/egg/pk.asn.h
@@ -70,6 +70,7 @@ const asn1_static_node pk_asn1_tab[] = {
   { "ECPoint", 1073741831, NULL },
   { "ECParameters", 1610612754, NULL },
   { "namedCurve", 12, NULL },
+  { "ECKeyQ", 1073741831, NULL },
   { "ECPrivateKey", 536870917, NULL },
   { "version", 1610874883, NULL },
   { "ecPrivkeyVer1", 1, "1"},

--- a/gcr/gcr-openssh.c
+++ b/gcr/gcr-openssh.c
@@ -247,6 +247,39 @@ parse_v1_public_line (const gchar *line,
 }
 
 static gboolean
+read_buffer_mpi_to_der (EggBuffer *buffer,
+                        gsize *offset,
+                        GckBuilder *builder,
+                        gulong attribute_type)
+{
+	const guchar *data, *data_value;
+	GBytes *der_data = NULL;
+	gsize len, data_len;
+	GNode *asn = NULL;
+	gboolean rv = FALSE;
+
+	if (!egg_buffer_get_byte_array (buffer, *offset, offset, &data, &len))
+		return FALSE;
+
+	asn = egg_asn1x_create (pk_asn1_tab, "ECKeyQ");
+	if (!asn)
+		return FALSE;
+
+	egg_asn1x_set_string_as_raw (asn, data, len, NULL);
+	der_data = egg_asn1x_encode (asn, g_realloc);
+	if (!der_data)
+		goto out;
+
+	data_value = g_bytes_get_data (der_data, &data_len);
+	gck_builder_add_data (builder, attribute_type, data_value, data_len);
+	rv = TRUE;
+out:
+	g_bytes_unref (der_data);
+	egg_asn1x_destroy (asn);
+	return rv;
+}
+
+static gboolean
 read_buffer_mpi (EggBuffer *buffer,
                  gsize *offset,
                  GckBuilder *builder,
@@ -346,7 +379,8 @@ read_v2_public_ecdsa (EggBuffer *buffer,
 	gck_builder_add_data (builder, CKA_EC_PARAMS, data, len);
 	g_bytes_unref (bytes);
 
-	if (!read_buffer_mpi (buffer, offset, builder, CKA_EC_POINT))
+	/* need to convert to DER encoded OCTET STRING */
+	if (!read_buffer_mpi_to_der (buffer, offset, builder, CKA_EC_POINT))
 		return FALSE;
 
 	gck_builder_add_ulong (builder, CKA_KEY_TYPE, CKK_ECDSA);

--- a/gcr/gcr-parser.c
+++ b/gcr/gcr-parser.c
@@ -279,6 +279,25 @@ parsed_asn1_element (GcrParsed *parsed,
 	return TRUE;
 }
 
+static gboolean
+parsed_asn1_structure (GcrParsed *parsed,
+                      GNode *asn,
+                      CK_ATTRIBUTE_TYPE type)
+{
+	GBytes *value;
+
+	g_assert (asn);
+	g_assert (parsed);
+
+	value = egg_asn1x_encode (asn, g_realloc);
+	if (value == NULL)
+		return FALSE;
+
+	parsed_attribute_bytes (parsed, type, value);
+	g_bytes_unref (value);
+	return TRUE;
+}
+
 static void
 parsed_ulong_attribute (GcrParsed *parsed,
                         CK_ATTRIBUTE_TYPE type,
@@ -625,6 +644,7 @@ parse_der_private_key_ec (GcrParser *self,
 	GNode *asn = NULL;
 	GBytes *value = NULL;
 	GBytes *pub = NULL;
+	GNode *asn_q = NULL;
 	GcrParsed *parsed;
 	guint bits;
 	gulong version;
@@ -660,8 +680,16 @@ parse_der_private_key_ec (GcrParser *self,
 	parsed_attribute_bytes (parsed, CKA_VALUE, value);
 
 	pub = egg_asn1x_get_bits_as_raw (egg_asn1x_node (asn, "publicKey", NULL), &bits);
-	if (pub && bits  == 8 * g_bytes_get_size (pub))
-		parsed_attribute_bytes (parsed, CKA_EC_POINT, pub);
+	if (!pub || bits != 8 * g_bytes_get_size (pub))
+		goto done;
+	asn_q = egg_asn1x_create (pk_asn1_tab, "ECKeyQ");
+	if (!asn_q)
+		goto done;
+	egg_asn1x_set_string_as_bytes (asn_q, pub);
+
+	if (!parsed_asn1_structure (parsed, asn_q, CKA_EC_POINT))
+		goto done;
+
 	parsed_fire (self, parsed);
 	ret = SUCCESS;
 
@@ -671,6 +699,7 @@ done:
 	if (value)
 		g_bytes_unref (value);
 	egg_asn1x_destroy (asn);
+	egg_asn1x_destroy (asn_q);
 	if (ret == GCR_ERROR_FAILURE)
 		g_message ("invalid EC key");
 


### PR DESCRIPTION
 * The PKCS#11 specification described this attribute as DER encoded and
   existing tools expect the value as an OCTET STRING
 * This breaks the tests, which expect the value to be in raw. The affected
   file is  gcr/fixtures/ecc-strong.spk  to my best understanding